### PR TITLE
Support DomElastica refs on React 18

### DIFF
--- a/packages/react/src/dom/dom-elastica.tsx
+++ b/packages/react/src/dom/dom-elastica.tsx
@@ -8,6 +8,7 @@ import Elastica, {
 } from '@darkroom.engineering/elastica'
 import { useFrame, useRect } from '@darkroom.engineering/hamo'
 import {
+  forwardRef,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -15,7 +16,6 @@ import {
   useRef,
   useState,
   type ReactNode,
-  type Ref,
   type RefObject,
 } from 'react'
 import { ElasticaContext, type DomElasticaContextValue } from '../context'
@@ -35,7 +35,6 @@ export type DomElasticaProps = {
   initialCondition?: (params: InitialConditionParams) => void
   update?: (params: UpdateParams) => void
   showHashGrid?: boolean
-  ref?: Ref<DomElasticaRef>
 }
 
 // Default config values
@@ -80,15 +79,18 @@ const DEFAULT_CONFIG: ElasticaConfigOBB = {
  * ```
  */
 
-export function DomElastica({
-  children,
-  className,
-  config,
-  initialCondition = () => {},
-  update = () => {},
-  showHashGrid = false,
-  ref,
-}: DomElasticaProps) {
+export const DomElastica = forwardRef<DomElasticaRef, DomElasticaProps>(
+  function DomElastica(
+    {
+      children,
+      className,
+      config,
+      initialCondition = () => {},
+      update = () => {},
+      showHashGrid = false,
+    },
+    ref
+  ) {
     const timeRef = useRef(0)
     const isPausedRef = useRef(false)
     const boxesRefs = useRef(new Map<HTMLElement, ElementData>())
@@ -256,4 +258,5 @@ export function DomElastica({
         </ElasticaContext.Provider>
       </div>
   )
-}
+  }
+)


### PR DESCRIPTION
Fixes #15.

## What changed

- Wrapped `DomElastica` with `forwardRef`.
- Kept the existing `DomElasticaRef` imperative API for `play()` and `pause()`.
- Removed `ref` from `DomElasticaProps` so React handles it as a real ref instead of a normal prop.

## Why

The package allows React `>=18.2`, but plain function component `ref` props only work with React 19 behavior. In React 18, the ref is not delivered to `DomElastica` as a normal prop, so the imperative `play()` and `pause()` handle cannot be used reliably.

Using `forwardRef` preserves React 18 support without requiring a peer dependency bump.

## Validation

- `node_modules\.bin\tsc.cmd -p packages\react\tsconfig.json --noEmit`
- `npm --prefix packages\react run build`
